### PR TITLE
Disable GitHub Email Validation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: lint $(BINARY)
 .PHONY: clean
 clean:
 	-rm -rf release
-	-rm -f $(BINARY)
+	-rm -f $(BINARY)-amd64 $(BINARY)-arm64
 
 .PHONY: distclean
 distclean: clean
@@ -39,8 +39,13 @@ lint: validate-go-version
 .PHONY: build
 build: validate-go-version clean $(BINARY)
 
-$(BINARY):
-	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
+$(BINARY): $(BINARY)-amd64 $(BINARY)-arm64
+
+$(BINARY)-amd64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
+
+$(BINARY)-arm64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
 
 DOCKER_BUILD_PLATFORM         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v7,linux/s390x
 DOCKER_BUILD_RUNTIME_IMAGE    ?= gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: lint $(BINARY)
 .PHONY: clean
 clean:
 	-rm -rf release
-	-rm -f $(BINARY)-amd64 $(BINARY)-arm64
+	-rm -f $(BINARY)
 
 .PHONY: distclean
 distclean: clean

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -497,6 +497,7 @@ type LegacyProvider struct {
 	GitHubRepo                             string   `flag:"github-repo" cfg:"github_repo"`
 	GitHubToken                            string   `flag:"github-token" cfg:"github_token"`
 	GitHubUsers                            []string `flag:"github-user" cfg:"github_users"`
+	GitHubSkipEmailVerificationCheck       bool     `flag:"github-skip-email-verification-check" cfg:"github_skip_email_verification_check"`
 	GitLabGroup                            []string `flag:"gitlab-group" cfg:"gitlab_groups"`
 	GitLabProjects                         []string `flag:"gitlab-project" cfg:"gitlab_projects"`
 	GoogleGroupsLegacy                     []string `flag:"google-group" cfg:"google_group"`
@@ -561,6 +562,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.String("github-repo", "", "restrict logins to collaborators of this repository")
 	flagSet.String("github-token", "", "the token to use when verifying repository collaborators (must have push access to the repository)")
+	flagSet.String("github-skip-email-verification-check", "", "optionally skip github email verification checks, unverified and verified emails will be treated the same")
 	flagSet.StringSlice("github-user", []string{}, "allow users with these usernames to login even if they do not belong to the specified org and team or collaborators (may be given multiple times)")
 	flagSet.StringSlice("gitlab-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
 	flagSet.StringSlice("gitlab-project", []string{}, "restrict logins to members of this project (may be given multiple times) (eg `group/project=accesslevel`). Access level should be a value matching Gitlab access levels (see https://docs.gitlab.com/ee/api/members.html#valid-access-levels), defaulted to 20 if absent")
@@ -717,11 +719,12 @@ func (l *LegacyProvider) convert() (Providers, error) {
 	switch provider.Type {
 	case "github":
 		provider.GitHubConfig = GitHubOptions{
-			Org:   l.GitHubOrg,
-			Team:  l.GitHubTeam,
-			Repo:  l.GitHubRepo,
-			Token: l.GitHubToken,
-			Users: l.GitHubUsers,
+			Org:                        l.GitHubOrg,
+			Team:                       l.GitHubTeam,
+			Repo:                       l.GitHubRepo,
+			Token:                      l.GitHubToken,
+			Users:                      l.GitHubUsers,
+			SkipEmailVerificationCheck: l.GitHubSkipEmailVerificationCheck,
 		}
 	case "keycloak-oidc":
 		provider.KeycloakConfig = KeycloakOptions{

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -498,6 +498,7 @@ type LegacyProvider struct {
 	GitHubToken                            string   `flag:"github-token" cfg:"github_token"`
 	GitHubUsers                            []string `flag:"github-user" cfg:"github_users"`
 	GitHubSkipEmailVerificationCheck       bool     `flag:"github-skip-email-verification-check" cfg:"github_skip_email_verification_check"`
+	GitHubEnableEmailEndpointLogging       bool     `flag:"github-enable-email-endpoint-logging" cfg:"github_enable_email_endpoint_logging"`
 	GitLabGroup                            []string `flag:"gitlab-group" cfg:"gitlab_groups"`
 	GitLabProjects                         []string `flag:"gitlab-project" cfg:"gitlab_projects"`
 	GoogleGroupsLegacy                     []string `flag:"google-group" cfg:"google_group"`
@@ -562,7 +563,8 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.String("github-repo", "", "restrict logins to collaborators of this repository")
 	flagSet.String("github-token", "", "the token to use when verifying repository collaborators (must have push access to the repository)")
-	flagSet.String("github-skip-email-verification-check", "", "optionally skip github email verification checks, unverified and verified emails will be treated the same")
+	flagSet.Bool("github-skip-email-verification-check", false, "optionally skip github email verification checks, unverified and verified emails will be treated the same")
+	flagSet.Bool("github-enable-email-endpoint-logging", false, "enable detailed logging of GitHub email endpoint requests/responses")
 	flagSet.StringSlice("github-user", []string{}, "allow users with these usernames to login even if they do not belong to the specified org and team or collaborators (may be given multiple times)")
 	flagSet.StringSlice("gitlab-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
 	flagSet.StringSlice("gitlab-project", []string{}, "restrict logins to members of this project (may be given multiple times) (eg `group/project=accesslevel`). Access level should be a value matching Gitlab access levels (see https://docs.gitlab.com/ee/api/members.html#valid-access-levels), defaulted to 20 if absent")
@@ -725,6 +727,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 			Token:                      l.GitHubToken,
 			Users:                      l.GitHubUsers,
 			SkipEmailVerificationCheck: l.GitHubSkipEmailVerificationCheck,
+			EnableEmailEndpointLogging: l.GitHubEnableEmailEndpointLogging,
 		}
 	case "keycloak-oidc":
 		provider.KeycloakConfig = KeycloakOptions{

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -198,6 +198,8 @@ type GitHubOptions struct {
 	// Users allows users with these usernames to login
 	// even if they do not belong to the specified org and team or collaborators
 	Users []string `json:"users,omitempty"`
+	//Skip checking if email address is verified by github. Default value is 'false'
+	SkipEmailVerificationCheck bool `json:"skipEmailVerificationCheck,omitempty"`
 }
 
 type GitLabOptions struct {

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -200,6 +200,8 @@ type GitHubOptions struct {
 	Users []string `json:"users,omitempty"`
 	//Skip checking if email address is verified by github. Default value is 'false'
 	SkipEmailVerificationCheck bool `json:"skipEmailVerificationCheck,omitempty"`
+	// EnableEmailEndpointLogging enables detailed logging of GitHub email endpoint requests/responses
+	EnableEmailEndpointLogging bool `json:"enableEmailEndpointLogging,omitempty"`
 }
 
 type GitLabOptions struct {

--- a/providers/github.go
+++ b/providers/github.go
@@ -312,12 +312,16 @@ func (p *GitHubProvider) getEmail(ctx context.Context, s *sessions.SessionState)
 	}
 
 	endpoint := p.makeGitHubAPIEndpoint("/user/emails", nil)
+	logger.Printf("GitHub API Request - GET %s", endpoint.String())
 
-	err := requests.New(endpoint.String()).
+	result := requests.New(endpoint.String()).
 		WithContext(ctx).
 		WithHeaders(makeGitHubHeader(s.AccessToken)).
-		Do().
-		UnmarshalInto(&emails)
+		Do()
+	
+	logger.Printf("GitHub API Response - Status: %d, Body: %s", result.StatusCode(), result.Body())
+	
+	err := result.UnmarshalInto(&emails)
 	if err != nil {
 		return err
 	}

--- a/providers/github.go
+++ b/providers/github.go
@@ -27,6 +27,7 @@ type GitHubProvider struct {
 	Token                      string
 	Users                      []string
 	SkipEmailVerificationCheck bool
+	EnableEmailEndpointLogging bool
 }
 
 var _ Provider = (*GitHubProvider)(nil)
@@ -82,6 +83,7 @@ func NewGitHubProvider(p *ProviderData, opts options.GitHubOptions) *GitHubProvi
 	provider.setRepo(opts.Repo, opts.Token)
 	provider.setUsers(opts.Users)
 	provider.setSkipEmailVerificationCheck(opts.SkipEmailVerificationCheck)
+	provider.setEnableEmailEndpointLogging(opts.EnableEmailEndpointLogging)
 	return provider
 }
 
@@ -134,6 +136,11 @@ func (p *GitHubProvider) setUsers(users []string) {
 // setSkipEmailVerificationCheck disables checking of verificaiton status of github provided email
 func (p *GitHubProvider) setSkipEmailVerificationCheck(skipEmailVerificationCheck bool) {
 	p.SkipEmailVerificationCheck = skipEmailVerificationCheck
+}
+
+// setEnableEmailEndpointLogging enables detailed logging of GitHub email endpoint requests/responses
+func (p *GitHubProvider) setEnableEmailEndpointLogging(enableEmailEndpointLogging bool) {
+	p.EnableEmailEndpointLogging = enableEmailEndpointLogging
 }
 
 // EnrichSession updates the User & Email after the initial Redeem
@@ -319,14 +326,19 @@ func (p *GitHubProvider) getEmail(ctx context.Context, s *sessions.SessionState)
 	}
 
 	endpoint := p.makeGitHubAPIEndpoint("/user/emails", nil)
-	logger.Printf("GitHub API Request - GET %s", endpoint.String())
+
+	if p.EnableEmailEndpointLogging {
+		logger.Printf("GitHub API Request - GET %s", endpoint.String())
+	}
 
 	result := requests.New(endpoint.String()).
 		WithContext(ctx).
 		WithHeaders(makeGitHubHeader(s.AccessToken)).
 		Do()
 
-	logger.Printf("GitHub API Response - Status: %d, Body: %s", result.StatusCode(), result.Body())
+	if p.EnableEmailEndpointLogging {
+		logger.Printf("GitHub API Response - Status: %d, Body: %s", result.StatusCode(), result.Body())
+	}
 
 	err := result.UnmarshalInto(&emails)
 	if err != nil {

--- a/providers/github.go
+++ b/providers/github.go
@@ -21,11 +21,12 @@ import (
 // GitHubProvider represents an GitHub based Identity Provider
 type GitHubProvider struct {
 	*ProviderData
-	Org   string
-	Team  string
-	Repo  string
-	Token string
-	Users []string
+	Org                        string
+	Team                       string
+	Repo                       string
+	Token                      string
+	Users                      []string
+	SkipEmailVerificationCheck bool
 }
 
 var _ Provider = (*GitHubProvider)(nil)
@@ -80,6 +81,7 @@ func NewGitHubProvider(p *ProviderData, opts options.GitHubOptions) *GitHubProvi
 	provider.setOrgTeam(opts.Org, opts.Team)
 	provider.setRepo(opts.Repo, opts.Token)
 	provider.setUsers(opts.Users)
+	provider.setSkipEmailVerificationCheck(opts.SkipEmailVerificationCheck)
 	return provider
 }
 
@@ -127,6 +129,11 @@ func (p *GitHubProvider) setRepo(repo, token string) {
 // setUsers configures allowed usernames
 func (p *GitHubProvider) setUsers(users []string) {
 	p.Users = users
+}
+
+// setSkipEmailVerificationCheck disables checking of verificaiton status of github provided email
+func (p *GitHubProvider) setSkipEmailVerificationCheck(skipEmailVerificationCheck bool) {
+	p.SkipEmailVerificationCheck = skipEmailVerificationCheck
 }
 
 // EnrichSession updates the User & Email after the initial Redeem
@@ -318,20 +325,18 @@ func (p *GitHubProvider) getEmail(ctx context.Context, s *sessions.SessionState)
 		WithContext(ctx).
 		WithHeaders(makeGitHubHeader(s.AccessToken)).
 		Do()
-	
+
 	logger.Printf("GitHub API Response - Status: %d, Body: %s", result.StatusCode(), result.Body())
-	
+
 	err := result.UnmarshalInto(&emails)
 	if err != nil {
 		return err
 	}
 
 	for _, email := range emails {
-		if email.Verified {
-			if email.Primary {
-				s.Email = email.Email
-				return nil
-			}
+		if email.Primary && (p.SkipEmailVerificationCheck || email.Verified) {
+			s.Email = email.Email
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Adds two new settings to the proxy that can be configured on the cli or config file.

> `github_skip_email_verification_check = true`

`true` value skips checking email verification status from GitHub.  Verified/Unverified emails are treated as the same.
 
> `github_enable_email_endpoint_logging = false`

`true` value logs response from GitHub `/user/emails` made during auth flow

This branch also hacks up the `make build` to produce linux `amd64` `arm64` builds only. 